### PR TITLE
OT231-32: add endpoint delete User

### DIFF
--- a/src/main/java/com/alkemy/ong/application/repository/IUserRepository.java
+++ b/src/main/java/com/alkemy/ong/application/repository/IUserRepository.java
@@ -8,4 +8,9 @@ public interface IUserRepository {
 
   User add(User user);
 
+  boolean existsById(Long id);
+
+  boolean isDeleted(Long id);
+
+  void delete(Long id);
 }

--- a/src/main/java/com/alkemy/ong/application/service/UserService.java
+++ b/src/main/java/com/alkemy/ong/application/service/UserService.java
@@ -1,14 +1,17 @@
 package com.alkemy.ong.application.service;
 
+import com.alkemy.ong.application.exception.RecordNotFoundException;
 import com.alkemy.ong.application.exception.UserAlreadyExistsException;
 import com.alkemy.ong.application.repository.IUserRepository;
 import com.alkemy.ong.application.service.usecase.ICreateUserUseCase;
+import com.alkemy.ong.application.service.usecase.IDeleteMemberUseCase;
+import com.alkemy.ong.application.service.usecase.IDeleteUserUseCase;
 import com.alkemy.ong.domain.User;
 import com.alkemy.ong.infrastructure.config.spring.security.common.Role;
 import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
-public class UserService implements ICreateUserUseCase {
+public class UserService implements ICreateUserUseCase, IDeleteUserUseCase {
 
   private final IUserRepository userRepository;
 
@@ -22,4 +25,11 @@ public class UserService implements ICreateUserUseCase {
     return userRepository.add(newUser);
   }
 
+  @Override
+  public void delete(Long id) {
+    if (!userRepository.existsById(id) || userRepository.isDeleted(id)) {
+      throw new RecordNotFoundException("User not found.");
+    }
+    userRepository.delete(id);
+  }
 }

--- a/src/main/java/com/alkemy/ong/application/service/usecase/IDeleteUserUseCase.java
+++ b/src/main/java/com/alkemy/ong/application/service/usecase/IDeleteUserUseCase.java
@@ -1,0 +1,6 @@
+package com.alkemy.ong.application.service.usecase;
+
+public interface IDeleteUserUseCase {
+
+  void delete(Long id);
+}

--- a/src/main/java/com/alkemy/ong/infrastructure/database/repository/IUserSpringRepository.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/database/repository/IUserSpringRepository.java
@@ -1,12 +1,23 @@
 package com.alkemy.ong.infrastructure.database.repository;
 
 import com.alkemy.ong.infrastructure.database.entity.UserEntity;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface IUserSpringRepository extends JpaRepository<UserEntity, Long> {
 
   UserEntity findByEmail(String username);
+
+  @Query(value = "SELECT u FROM UserEntity u WHERE u.softDelete = true")
+  Optional<UserEntity> isDeleted(Long id);
+
+  @Modifying
+  @Query(value = "UPDATE UserEntity u SET u.softDelete = true WHERE u.id = :id")
+  void softDeleteById(@Param("id") Long id);
 
 }

--- a/src/main/java/com/alkemy/ong/infrastructure/database/repository/UserRepository.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/database/repository/UserRepository.java
@@ -30,8 +30,23 @@ public class UserRepository implements IUserRepository {
     return userEntityMapper.toDomain(userSpringRepository.save(userEntity));
   }
 
+  @Override
+  public boolean existsById(Long id) {
+    return userSpringRepository.existsById(id);
+  }
+
+  @Override
+  public boolean isDeleted(Long id) {
+    return userSpringRepository.isDeleted(id).isPresent();
+  }
+
   private RoleEntity getRoleEntity(String role) {
     return roleSpringRepository.findByName(role);
   }
 
+  @Override
+  @Transactional
+  public void delete(Long id) {
+    userSpringRepository.softDeleteById(id);
+  }
 }

--- a/src/main/java/com/alkemy/ong/infrastructure/rest/resource/UserResource.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/rest/resource/UserResource.java
@@ -1,6 +1,7 @@
 package com.alkemy.ong.infrastructure.rest.resource;
 
 import com.alkemy.ong.application.service.usecase.ICreateUserUseCase;
+import com.alkemy.ong.application.service.usecase.IDeleteUserUseCase;
 import com.alkemy.ong.domain.User;
 import com.alkemy.ong.infrastructure.rest.mapper.UserRegisterMapper;
 import com.alkemy.ong.infrastructure.rest.request.UserRegisterRequest;
@@ -9,6 +10,8 @@ import javax.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,6 +25,9 @@ public class UserResource {
   @Autowired
   private UserRegisterMapper userRegisterMapper;
 
+  @Autowired
+  private IDeleteUserUseCase deleteUserUseCase;
+
   @PostMapping(value = "auth/register",
       produces = {"application/json"},
       consumes = {"application/json"})
@@ -30,6 +36,12 @@ public class UserResource {
     User user = userRegisterMapper.toDomain(registerRequest);
     UserRegisterResponse response = userRegisterMapper.toResponse(createUserUseCase.add(user));
     return new ResponseEntity<UserRegisterResponse>(response, HttpStatus.CREATED);
+  }
+
+  @DeleteMapping(value = "/{id}")
+  public ResponseEntity<Void> delete(@PathVariable Long id) {
+    deleteUserUseCase.delete(id);
+    return ResponseEntity.noContent().build();
   }
 
 }


### PR DESCRIPTION
# [OT231-32](https://alkemy-labs.atlassian.net/browse/{replaceWithYourTicket#})

- Endpoint DELETE a /users/:id 
- Recibe el id del usuario con el método DELETE
- Borrado de tipo lógico
- Si el usuario no existe o ya está marcado como borrado, devuelve mensaje de error: “User not found.“

### HOW HAS THIS BEEN TESTED?


- [ ] Postman.
- [ ] Unit test.
- [ ] Integration test.
- [ ] No testing required (only applies for tech task).

**Test Configuration**:

* ...
* ...

**Screenshots**:

* ....

### CHECKLIST

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added the new resource in the Postman Collection file.
