### PR TITLE
OT231-24: (fix) User authentication endpoint bug

### DIFF
--- a/src/main/java/com/alkemy/ong/infrastructure/database/repository/UserRepository.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/database/repository/UserRepository.java
@@ -28,6 +28,7 @@ public class UserRepository implements IUserRepository {
   @Transactional
   public User add(User newUser) {
     UserEntity userEntity = userEntityMapper.toEntity(newUser);
+    userEntity.setSoftDelete(false);
     userEntity.setRole(getRoleEntity(newUser.getRole()));
     return userEntityMapper.toDomain(userSpringRepository.save(userEntity));
   }


### PR DESCRIPTION
# [Ticket OT231-24](https://alkemy-labs.atlassian.net/browse/OT231-24)

### RESUME

Modified UserRepository: it nows sets as `false` the `softDelete` attribute in UserEntity.

By default, the User Repository was setting as null the `softDelete` attribute when a User was created through the **auth/register** endpoint, thus throwing an **InvalidCredentialsException** when trying to authenticate that user through the **auth/login** endpoint.


### HOW HAS THIS BEEN TESTED?

- [X] Postman.
- [ ] Unit test.
- [ ] Integration test.
- [ ] No testing required (only applies for tech task).

### CHECKLIST

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [X] New and existing unit tests pass locally with my changes.
- [ ] I have added the new resource in the Postman Collection file.
