### PR TITLE
[Bug fixing] rename bean methods in seeders

### DIFF
--- a/src/main/java/com/alkemy/ong/infrastructure/config/seeder/SeedActivities.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/config/seeder/SeedActivities.java
@@ -23,7 +23,7 @@ public class SeedActivities {
   protected IActivitySpringRepository activitySpringRepository;
 
   @Bean
-  CommandLineRunner initDatabase() {
+  CommandLineRunner initActivityData() {
     return args -> {
       log.info("Loading initial Activities in Database...");
       createStandarActivity();

--- a/src/main/java/com/alkemy/ong/infrastructure/config/seeder/SeedUsers.java
+++ b/src/main/java/com/alkemy/ong/infrastructure/config/seeder/SeedUsers.java
@@ -41,7 +41,7 @@ public class SeedUsers {
   protected IRoleSpringRepository roleRepository;
 
   @Bean
-  CommandLineRunner initDatabase() {
+  CommandLineRunner initUsersData() {
     return args -> {
       log.info("Loading initial Roles in Database...");
       createRoles();


### PR DESCRIPTION
Bug: both seeders had `@Bean` methods with identical names.