### PR TITLE
[Bug fixing] - Fix UUID setting in Slide

### DIFF
--- a/src/main/java/com/alkemy/ong/domain/Slide.java
+++ b/src/main/java/com/alkemy/ong/domain/Slide.java
@@ -17,6 +17,7 @@ public class Slide implements IImage {
   private String text;
   private Integer order;
   private String base64File;
+  private final UUID uuid = UUID.randomUUID();
 
   @Override
   public InputStream getFile() {
@@ -26,7 +27,6 @@ public class Slide implements IImage {
 
   @Override
   public String getFileName() {
-    UUID uuid = UUID.randomUUID();
     return uuid.toString();
   }
 


### PR DESCRIPTION
Bug: `getFileName` in **Slide** was setting twice the UUID, first when it was called by the `putObject` method in **UploadImageDelegate**, and after that when the `getUrl` method was called